### PR TITLE
Tancredi provisioning

### DIFF
--- a/admin-manual/index.rst
+++ b/admin-manual/index.rst
@@ -47,7 +47,8 @@ Configurazione Base
 .. toctree::
    :maxdepth: 2
 
-   wizard
+   wizard2
+   wizard2_provisioning
    dashboard
    app_mobile
 
@@ -57,9 +58,9 @@ Provisioning
 .. toctree::
    :maxdepth: 2
 
-   provisioning_phone
+   provisioning_phone2
+   provisioning_migration
    provisioning_gateway
-   wizard2_provisioning
 
 Configurazione Avanzata
 -----------------------

--- a/admin-manual/provisioning_migration.rst
+++ b/admin-manual/provisioning_migration.rst
@@ -1,3 +1,5 @@
+.. _provisioning-migration-section:
+
 =====================
 Migrazione a Tancredi
 =====================

--- a/admin-manual/provisioning_phone.rst
+++ b/admin-manual/provisioning_phone.rst
@@ -1,13 +1,14 @@
 .. _provisioning-section:
 
-=========================
-Provisioning dei telefoni
-=========================
+====================================
+Provisioning dei telefoni (obsoleto)
+====================================
 
-.. note::
+.. warning::
 
    Il nuovo sistema di provisioning basato sul progetto Tancredi è descritto in
-   :ref:`provisioning-phone2-section`
+   :ref:`provisioning-phone2-section`. Per la procedura di migrazione consultare
+   :ref:`provisioning-migration-section`.
 
 
 Telefoni supportati

--- a/admin-manual/provisioning_phone2.rst
+++ b/admin-manual/provisioning_phone2.rst
@@ -1,15 +1,14 @@
 
 .. _provisioning-phone2-section:
 
-================================
-Provisioning dei telefoni (beta)
-================================
+=========================
+Provisioning dei telefoni
+=========================
 
-.. warning::
+.. hint::
     
-    Le funzioni descritte in questa pagina sono disponibili in anteprima solo ai
-    membri del |product| Quality Team. Fare riferimento a
-    :ref:`provisioning-section` per la versione stabile
+    Fare riferimento a :ref:`provisioning-migration-section` e a
+    :ref:`provisioning-section` per la versione precedente.
 
 
 Cosa significa **Provisioning**? Provisioning è configurare i telefoni in

--- a/admin-manual/wizard.rst
+++ b/admin-manual/wizard.rst
@@ -1,10 +1,10 @@
 .. _wizard-section:
 
-===========================
-Wizard prima configurazione
-===========================
+======================================
+Wizard prima configurazione (obsoleto)
+======================================
 
-.. note::
+.. warning::
 
    Il nuovo sistema di provisioning basato sul progetto Tancredi è descritto in
    :ref:`wizard2-section`

--- a/admin-manual/wizard2.rst
+++ b/admin-manual/wizard2.rst
@@ -1,14 +1,12 @@
 .. _wizard2-section:
 
-==================================
-Wizard prima configurazione (beta)
-==================================
+===========================
+Wizard prima configurazione
+===========================
 
 .. warning::
     
-    Le funzioni descritte in questa sezione sono disponibili in anteprima solo
-    ai membri del |product| Quality Team. Fare riferimento a
-    :ref:`wizard-section` per la versione stabile.
+    Fare riferimento a :ref:`wizard-section` per la versione precedente
 
 In questa sezione sono descritte le nuove funzionalità introdotte dal
 :ref:`nuovo sistema di provisioning <provisioning-phone2-section>` basato sul

--- a/admin-manual/wizard2.rst
+++ b/admin-manual/wizard2.rst
@@ -4,7 +4,7 @@
 Wizard prima configurazione
 ===========================
 
-.. warning::
+.. hint::
     
     Fare riferimento a :ref:`wizard-section` per la versione precedente
 

--- a/admin-manual/wizard2_provisioning.rst
+++ b/admin-manual/wizard2_provisioning.rst
@@ -1,14 +1,12 @@
 .. _wizard2-provisioning-section:
 
-=========================================
-Guida ai parametri di provisioning (beta)
-=========================================
+==================================
+Guida ai parametri di provisioning
+==================================
 
-.. warning::
+.. hint::
     
-    Le funzioni descritte in questa sezione sono disponibili in anteprima solo
-    ai membri del |product| Quality Team. Fare riferimento a
-    :ref:`wizard-section` per la versione stabile.
+    Fare riferimento a :ref:`wizard-section` per la versione precedente
 
 Le funzioni dei telefoni configurabili mediante provisioning sono raccolte nei
 pannelli dell'interfaccia di amminstrazione di |product| e descritti nelle seguenti sezioni.


### PR DESCRIPTION
Swap the beta/stable pages. The Tancredi provisioning engine is now stable.

This PR requires #69 is already merged.

nethesis/dev#5833