### PR TITLE
Configure NethCTI with alias domain for QR code

### DIFF
--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -22,7 +22,6 @@ I requisiti per utillizzare l'app sono:
 
         config setprop nethvoice PublicHost ALIAS
         expand-template /etc/asterisk/nethcti_push_configuration.json
-
         expand-template /etc/nethcti/nethcti.json
 
         systemctl reload nethcti-server

--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -23,7 +23,6 @@ I requisiti per utillizzare l'app sono:
         config setprop nethvoice PublicHost ALIAS
         expand-template /etc/asterisk/nethcti_push_configuration.json
         expand-template /etc/nethcti/nethcti.json
-
         systemctl reload nethcti-server
 
 L'app accede in SIP TLS al |product| che va abilitato sia lato firewall che nella configurazione di |product|.

--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -21,9 +21,12 @@ I requisiti per utillizzare l'app sono:
    Per usarlo al posto del FQDN utilizzare questi comandi sostituendo ad ALIAS il nome host seguito dal dominio (ad esempio host.dominio.com): ::
 
         config setprop nethvoice PublicHost ALIAS
-
+        
         expand-template /etc/asterisk/nethcti_push_configuration.json
 
+        expand-template /etc/nethcti/nethcti.json
+
+        systemctl reload nethcti-server
 
 L'app accede in SIP TLS al |product| che va abilitato sia lato firewall che nella configurazione di |product|.
 

--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -21,7 +21,6 @@ I requisiti per utillizzare l'app sono:
    Per usarlo al posto del FQDN utilizzare questi comandi sostituendo ad ALIAS il nome host seguito dal dominio (ad esempio host.dominio.com): ::
 
         config setprop nethvoice PublicHost ALIAS
-        
         expand-template /etc/asterisk/nethcti_push_configuration.json
 
         expand-template /etc/nethcti/nethcti.json


### PR DESCRIPTION
Add command to configure NethCTi to use alias domain for QR Code.