### PR TITLE
Add expand config and restart flexisip for using alias

### DIFF
--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -23,6 +23,8 @@ I requisiti per utillizzare l'app sono:
         config setprop nethvoice PublicHost ALIAS
         expand-template /etc/asterisk/nethcti_push_configuration.json
         expand-template /etc/nethcti/nethcti.json
+        expand-template /etc/flexisip/flexisip.conf
+        systemctl restart flexisip-proxy
         systemctl reload nethcti-server
 
 L'app accede in SIP TLS al |product| che va abilitato sia lato firewall che nella configurazione di |product|.


### PR DESCRIPTION
For using app mobile with an alias it is necessary to configure and restart flexisip.