### PR TITLE
Add flexisip port

### DIFF
--- a/admin-manual/app_mobile.rst
+++ b/admin-manual/app_mobile.rst
@@ -17,6 +17,7 @@ I requisiti per utillizzare l'app sono:
 - protocollo SIP TLS raggiungibile
 - porta HTTPS raggiungibile
 - porta 6061 TCP raggiungibile
+- :guilabel:`Accesso SIPS esterno` deve essere abilitato nella pagina :guilabel:`Amministrazione -> Impostazioni` del wizard
 
 .. note:: In alternativa al FQDN del |product| è possibile usare un nome host e dominio configurato come alias per il server con gli stessi requisiti.
    Per usarlo al posto del FQDN utilizzare questi comandi sostituendo ad ALIAS il nome host seguito dal dominio (ad esempio host.dominio.com): ::

--- a/admin-manual/wizard2.rst
+++ b/admin-manual/wizard2.rst
@@ -370,6 +370,7 @@ La pagina delle Impostazioni permette di gestire diversi aspetti della configura
 
 * :guilabel:`Impostazioni Firewall`: il firewall di |product| nella configurazione di partenza non accetta connessioni da reti esterne per il protocollo SIP TLS (porta 5061 tcp e porte da 10000 a 20000 udp).
   In questa sezione è possibile configurare il firewall per accettare traffico SIP TLS anche da reti non locali abilitando il SIPS esterno.
+  Abilitando l'accesso SIPS esterno, si concede anche l'accesso in TLS al proxy Flexisip sulla porta 6061, che consente l'uso dell'App mobile.
 
 * :guilabel:`Impostazioni Rubrica`: in questa sezione è possibile abilitare l'esporazione della rubrica di |product| in LDAP per consentire di solito ai telefoni di accedervi in sola lettura.
   La rubrica può essere pubblicata in LDAP in due modalità (la configurazione data ai telefoni sarà completa di tutti i parametri necessari):


### PR DESCRIPTION
Flexisip port needs to be opened for mobile app. This function has been
added to "Use external SIPS" switch
https://github.com/nethesis/dev/issues/5963