### PR TITLE
Add a restore note for app push notification

### DIFF
--- a/admin-manual/backup_restore.rst
+++ b/admin-manual/backup_restore.rst
@@ -22,4 +22,4 @@ Disaster recovery
 
 Per il ripristino completo di un server dove era installato |product| vedere la documentazione relativa di |parent_product|: `Disaster recovery <http://nethserver.docs.nethesis.it/it/latest/backup.html>`_.
 
-.. warning:: Dopo il restore, le app NethCTI per Andorid e iOS non riceveranno più le notifiche finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.
+.. warning:: Dopo il restore, le app |product_cti| per Andorid e iOS non riceveranno più le notifiche finché non si registreranno di nuovo, ovvero finché non verranno aperte dall'utente.

--- a/admin-manual/backup_restore.rst
+++ b/admin-manual/backup_restore.rst
@@ -21,3 +21,5 @@ Disaster recovery
 =================
 
 Per il ripristino completo di un server dove era installato |product| vedere la documentazione relativa di |parent_product|: `Disaster recovery <http://nethserver.docs.nethesis.it/it/latest/backup.html>`_.
+
+.. note:: Dopo il restore, le app non riceveranno più le notifiche push finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.

--- a/admin-manual/backup_restore.rst
+++ b/admin-manual/backup_restore.rst
@@ -22,4 +22,4 @@ Disaster recovery
 
 Per il ripristino completo di un server dove era installato |product| vedere la documentazione relativa di |parent_product|: `Disaster recovery <http://nethserver.docs.nethesis.it/it/latest/backup.html>`_.
 
-.. note:: Dopo il restore, le app non riceveranno più le notifiche push finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.
+.. warning:: Dopo il restore, le app non riceveranno più le notifiche push finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.

--- a/admin-manual/backup_restore.rst
+++ b/admin-manual/backup_restore.rst
@@ -22,4 +22,4 @@ Disaster recovery
 
 Per il ripristino completo di un server dove era installato |product| vedere la documentazione relativa di |parent_product|: `Disaster recovery <http://nethserver.docs.nethesis.it/it/latest/backup.html>`_.
 
-.. warning:: Dopo il restore, le app non riceveranno più le notifiche push finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.
+.. warning:: Dopo il restore, le app NethCTI per Andorid e iOS non riceveranno più le notifiche finché non si registreranno di nuovo, ovvero finchè non verranno aperte dall'utente.


### PR DESCRIPTION
Redis persistent storage of flexisip registration isn't backed up, that means that push notifications won't be sent to devices until they don't register again. The registration happens when a user open sthe app.
https://github.com/nethesis/dev/issues/6021