### PR TITLE
Fixed missing px and wrong padding position

### DIFF
--- a/admin-manual/_static/nethesis.css
+++ b/admin-manual/_static/nethesis.css
@@ -119,7 +119,7 @@ pre, blockquote {
 }
 .section li {
     line-height: 28px;
-    font-size: 15;  
+    font-size: 15px;
 }
 .navbar-default .navbar-nav>li {
     border-right: #cccccc 1px solid !important;
@@ -382,6 +382,3 @@ footer .pull-right a:hover {
     background-color:#343131;
     }
 
-.hint {
-    padding: 50px !important;
-}


### PR DESCRIPTION
**Steps to reproduce**

At this moment the documentation has formatting errors due to a missing `px` inside the .css file and the padding is likewise incorrect

**Expected behavior**
- Adding the missing `px` inside the css file
- Removal of the .hint class which causes errors in page formatting
