### PR TITLE
Fixed missing px and wrong padding position

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 install:
     - sudo apt-get install sshpass
-    - pip install -r ${BUILD_DIR}/requirements.txt sphinx==3.2.1
+    - pip install -r ${BUILD_DIR}/requirements.txt sphinx==4.1.2
 
 script:
     - pushd ${BUILD_DIR}/

--- a/admin-manual/_static/nethesis.css
+++ b/admin-manual/_static/nethesis.css
@@ -119,7 +119,7 @@ pre, blockquote {
 }
 .section li {
     line-height: 28px;
-    font-size: 15;  
+    font-size: 15px;
 }
 .navbar-default .navbar-nav>li {
     border-right: #cccccc 1px solid !important;
@@ -381,7 +381,3 @@ footer .pull-right a:hover {
 .wy-side-nav-search {
     background-color:#343131;
     }
-
-.hint {
-    padding: 50px !important;
-}

--- a/admin-manual/requirements.txt
+++ b/admin-manual/requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme===0.5.1
+sphinx_rtd_theme===1.0.0


### PR DESCRIPTION
**Steps to reproduce**

At this moment the documentation has formatting errors due to a missing `px` inside the .css file and the padding is likewise incorrect

**Expected behavior**
- Adding the missing `px` inside the css file
- Removal of the .hint class which causes errors in page formatting